### PR TITLE
Output performance data in YAML format.

### DIFF
--- a/xolotl/perf/include/xolotl/perf/PerfObjStatistics.h
+++ b/xolotl/perf/include/xolotl/perf/PerfObjStatistics.h
@@ -79,18 +79,15 @@ struct PerfObjStatistics
 	void
 	outputTo(std::ostream& os) const
 	{
-		os << "  "
-		   << "name: " << name << '\n'
-		   << "    "
-		   << "process_count: " << processCount << '\n'
-		   << "    "
-		   << "min: " << min << '\n'
-		   << "    "
-		   << "max: " << max << '\n'
-		   << "    "
-		   << "average: " << average << '\n'
-		   << "    "
-		   << "stdev: " << stdev << '\n'
+		// Output data in YAML format.
+		constexpr char* nameIndent = "  ";
+		constexpr char* propIndent = "    ";
+		os << nameIndent << name << ":\n"
+		   << propIndent << "process_count: " << processCount << '\n'
+		   << propIndent << "min: " << min << '\n'
+		   << propIndent << "max: " << max << '\n'
+		   << propIndent << "average: " << average << '\n'
+		   << propIndent << "stdev: " << stdev << '\n'
 		   << std::endl;
 	}
 };

--- a/xolotl/perf/src/PerfHandler.cpp
+++ b/xolotl/perf/src/PerfHandler.cpp
@@ -383,7 +383,9 @@ PerfHandler::reportStatistics(std::ostream& os,
 	const PerfObjStatsMap<IEventCounter::ValType>& counterStats,
 	const PerfObjStatsMap<IHardwareCounter::CounterType>& hwCounterStats) const
 {
-	os << "\nTimers:\n";
+	// Output performance information in YAML format.
+	os << "\n---\n"
+	   << "Timers:\n";
 	for (auto iter = timerStats.begin(); iter != timerStats.end(); ++iter) {
 		iter->second.outputTo(os);
 	}


### PR DESCRIPTION
## What?
Changes output of performance data collected by Xolotl's built-in performance data infrastructure so that it is expressed in valid YAML format.

## Why?
Having performance data in YAML format supports ingest by other analysis tools, e.g. Python scripts that use the PyYAML module and then analyze or visualize the data.

## How?
Performance data was already being output to standard output.  The changes simply modify the formatting so that the output is in valid YAML format.
