### PR TITLE
Remove speculative ClusterConnectivity transpose code.

### DIFF
--- a/xolotl/core/include/xolotl/core/network/detail/ClusterConnectivity.h
+++ b/xolotl/core/include/xolotl/core/network/detail/ClusterConnectivity.h
@@ -32,40 +32,6 @@ public:
 	using HostMirror = ClusterConnectivity<
 		typename Kokkos::View<int*, TMemSpace>::traits::host_mirror_space>;
 
-	ClusterConnectivity&
-	operator=(const ClusterConnectivity& other)
-	{
-		Crs::operator=(other);
-		if (other._tr.row_map.size() == 0 && this->row_map.size() > 0) {
-			_tr = Crs();
-			Kokkos::transpose_crs(_tr, *this);
-			_trEntries = typename Crs::entries_type(
-				"transposed entries map", this->entries.size());
-			auto conn = *this;
-			auto nRows = conn.row_map.size() - 1;
-			Kokkos::parallel_for(
-				"ClusterConnectivity::assignTransposeEntries", nRows,
-				KOKKOS_LAMBDA(IndexType i) {
-					auto pBegin = conn.row_map(i);
-					auto pEnd = conn.row_map(i + 1);
-					for (auto p = pBegin; p < pEnd; ++p) {
-						auto j = conn.entries(p);
-						conn._trEntries(conn.getPosition(j, i, conn._tr)) = p;
-					}
-				});
-			Kokkos::fence();
-			_avgRowSize = static_cast<double>(conn.entries.size()) /
-					static_cast<double>(nRows) +
-				0.5;
-		}
-		else {
-			_tr = other._tr;
-			_trEntries = other._trEntries;
-			_avgRowSize = other._avgRowSize;
-		}
-		return *this;
-	}
-
 	KOKKOS_INLINE_FUNCTION
 	IndexType
 	getNumberOfRows() const
@@ -99,16 +65,7 @@ public:
 	IndexType
 	operator()(IndexType rowId, IndexType columnId) const
 	{
-		if (getRowSize(rowId) > _avgRowSize) {
-			auto trPos = getPosition(columnId, rowId, _tr);
-			if (trPos == invalidNetworkIndex) {
-				return invalidNetworkIndex;
-			}
-			return _trEntries(trPos);
-		}
-		else {
-			return getPosition(rowId, columnId, *this);
-		}
+        return getPosition(rowId, columnId, *this);
 	}
 
 	std::uint64_t
@@ -118,10 +75,6 @@ public:
 
 		ret += this->row_map.required_allocation_size(this->row_map.extent(0));
 		ret += this->entries.required_allocation_size(this->entries.extent(0));
-		ret += _tr.row_map.required_allocation_size(_tr.row_map.extent(0));
-		ret += _tr.entries.required_allocation_size(_tr.entries.extent(0));
-		ret += _trEntries.required_allocation_size(_trEntries.extent(0));
-		ret += sizeof(_avgRowSize);
 
 		return ret;
 	}
@@ -146,11 +99,6 @@ private:
 	{
 		return this->row_map(rowId + 1) - this->row_map(rowId);
 	}
-
-private:
-	Crs _tr;
-	typename Crs::entries_type _trEntries;
-	IndexType _avgRowSize{};
 };
 } // namespace detail
 } // namespace network


### PR DESCRIPTION
When built for CMake's RelWithDebInfo configuration, code in ClusterConnectivity that computes the transpose of the sparse matrix would cause SEGVs in device code, at least on CUDA devices.  My understanding is that the transpose code was added speculatively with the hope that using the transpose of the connectivity sparse matrix might be faster than the non-transposed matrix.  While that's still a valid idea to test, this implementation seems buggy on CUDA devices.