### PR TITLE
Update monitorBubble to use FeReactionNetwork instead of VReactionNetwork

### DIFF
--- a/analysis/live_bubble_plots.gp
+++ b/analysis/live_bubble_plots.gp
@@ -1,0 +1,53 @@
+# ==============================================================================
+# LIVE SIMULATION MONITORING SCRIPT USING GNUPLOT
+# ==============================================================================
+# 
+# WHAT THIS SCRIPT DOES:
+# This script creates a real-time, live-updating graphical dashboard for the
+# simulation data. It targets the file "bubbleV.dat" and extracts 3 different
+# physical metrics, plotting them simultaneously against Time (Column 1).
+#
+# EXPECTED DATA FORMAT (bubbleV.dat):
+# The script expects a file with at least 4 columns:
+# Column 1: Time (X-Axis for all plots)
+# Column 2: totalHe         Column 3: totalV          Column 4: bubbleDensity
+#
+# HOW TO RUN IT: 
+# gnuplot live_bubble_plots.gp
+#
+# HOW TO INTERACT WITH THE PLOT:
+# - This is a hands-off, automated viewer. It will scale itself and refresh
+#   automatically every second as new data is written by the simulation.
+# - Close: Press 'q' on your keyboard or Ctrl+C in the terminal to exit.
+#
+# PREREQUISITES:
+# Requires 'gnuplot-qt' or 'gnuplot-x11' for graphical display windows.
+# ==============================================================================
+
+set terminal qt size 800,1000  # Sets a tall window for stacked plots
+
+# Start an infinite loop using the "while" syntax
+while (1) {
+    set multiplot layout 3,1 title "Live Simulation Data" font ",14"
+
+    # Common settings for all plots
+    set xlabel "Time"
+    set grid
+
+    # Plot 1: totalHe
+    set ylabel "totalHe"
+    plot "bubbleV.dat" using 1:2 with lines lc rgb "blue" notitle
+
+    # Plot 2: totalV
+    set ylabel "totalV"
+    plot "bubbleV.dat" using 1:3 with lines lc rgb "red" notitle
+
+    # Plot 3: bubbleDensity
+    set ylabel "bubbleDensity"
+    plot "bubbleV.dat" using 1:4 with lines lc rgb "green" notitle
+
+    unset multiplot
+    
+    # Pause for 1 second before looping and replotting
+    pause 1
+}

--- a/xolotl/core/include/xolotl/core/network/VReactionNetwork.h
+++ b/xolotl/core/include/xolotl/core/network/VReactionNetwork.h
@@ -33,6 +33,29 @@ public:
 
 	IndexType
 	checkLargestClusterId();
+	
+	std::string
+	getMonitorOutputFileName() const override
+	{
+		return "V.dat";
+	}
+
+	std::string
+	getMonitorDataHeaderString() const override;
+
+	void
+	addMonitorDataValues(Kokkos::View<const double*> conc, double fac,
+		std::vector<double>& totalVals) override;
+
+	std::size_t
+	getMonitorDataLineSize() const override
+	{
+		return getSpeciesListSize() * 6;
+	}
+
+	void
+	writeMonitorDataLine(
+		const std::vector<double>& localData, double time) override;
 
 private:
 	double

--- a/xolotl/core/src/network/VReactionNetwork.cpp
+++ b/xolotl/core/src/network/VReactionNetwork.cpp
@@ -1,5 +1,6 @@
 #include <xolotl/core/network/VReactionNetwork.h>
 #include <xolotl/core/network/impl/VReactionNetwork.tpp>
+#include <xolotl/util/MPIUtils.h>
 
 namespace xolotl
 {
@@ -80,6 +81,96 @@ VReactionNetwork::checkLargestClusterId()
 		Reducer(maxLoc));
 
 	return maxLoc.loc;
+}
+
+std::string
+VReactionNetwork::getMonitorDataHeaderString() const
+{
+	std::stringstream header;
+
+	auto numSpecies = getSpeciesListSize();
+	header << "#time ";
+	for (auto id = SpeciesId(numSpecies); id; ++id) {
+		auto speciesName = this->getSpeciesName(id);
+		header << speciesName << "_density " << speciesName << "_atom "
+			   << speciesName << "_diameter " << speciesName
+			   << "_partial_density " << speciesName << "_partial_atom "
+			   << speciesName << "_partial_diameter ";
+	}
+
+	return header.str();
+}
+
+void
+VReactionNetwork::addMonitorDataValues(Kokkos::View<const double*> conc,
+	double fac, std::vector<double>& totalVals)
+{
+	auto numSpecies = getSpeciesListSize();
+	const auto& minSizes = this->getMinRadiusSizes();
+	for (auto id = SpeciesId(numSpecies); id; ++id) {
+		using TQ = IReactionNetwork::TotalQuantity;
+		using Q = TQ::Type;
+		using TQA = util::Array<TQ, 6>;
+		auto ms = minSizes[id()];
+		auto totals = this->getTotals(conc,
+			TQA{TQ{Q::total, id, 1}, TQ{Q::atom, id, 1}, TQ{Q::radius, id, 1},
+				TQ{Q::total, id, ms}, TQ{Q::atom, id, ms},
+				TQ{Q::radius, id, ms}});
+
+		totalVals[(6 * id()) + 0] += totals[0] * fac;
+		totalVals[(6 * id()) + 1] += totals[1] * fac;
+		totalVals[(6 * id()) + 2] += totals[2] * 2.0 * fac;
+		totalVals[(6 * id()) + 3] += totals[3] * fac;
+		totalVals[(6 * id()) + 4] += totals[4] * fac;
+		totalVals[(6 * id()) + 5] += totals[5] * 2.0 * fac;
+	}
+}
+
+void
+VReactionNetwork::writeMonitorDataLine(
+	const std::vector<double>& localData, double time)
+{
+	auto numSpecies = getSpeciesListSize();
+
+	// Sum all the concentrations through MPI reduce
+	auto globalData = std::vector<double>(localData.size(), 0.0);
+	MPI_Reduce(localData.data(), globalData.data(), localData.size(),
+		MPI_DOUBLE, MPI_SUM, 0, util::getMPIComm());
+
+	if (util::getMPIRank() == 0) {
+		// Average the data
+		for (auto i = 0; i < numSpecies; ++i) {
+			auto id = [i](std::size_t n) { return 6 * i + n; };
+			if (globalData[id(0)] > 1.0e-16) {
+				globalData[id(2)] /= globalData[id(0)];
+			}
+			if (globalData[id(3)] > 1.0e-16) {
+				globalData[id(5)] /= globalData[id(3)];
+			}
+		}
+
+		// Set the output precision
+		const int outputPrecision = 5;
+
+		// Open the output file
+		std::fstream outputFile;
+		outputFile.open(
+			getMonitorOutputFileName(), std::fstream::out | std::fstream::app);
+		outputFile << std::setprecision(outputPrecision);
+
+		// Output the data
+		outputFile << time << " ";
+		for (auto i = 0; i < numSpecies; ++i) {
+			auto id = [i](std::size_t n) { return 6 * i + n; };
+			outputFile << globalData[id(0)] << " " << globalData[id(1)] << " "
+					   << globalData[id(2)] << " " << globalData[id(3)] << " "
+					   << globalData[id(4)] << " " << globalData[id(5)] << " ";
+		}
+		outputFile << std::endl;
+
+		// Close the output file
+		outputFile.close();
+	}
 }
 } // namespace network
 } // namespace core

--- a/xolotl/solver/include/xolotl/solver/monitor/PetscMonitor0D.h
+++ b/xolotl/solver/include/xolotl/solver/monitor/PetscMonitor0D.h
@@ -56,12 +56,13 @@ public:
 	PetscErrorCode
 	computeAlphaZr(
 		TS ts, PetscInt timestep, PetscReal time, Vec solution) override;
+		
+	PetscErrorCode
+	computeV(
+		TS ts, PetscInt timestep, PetscReal time, Vec solution) ;
 
 //	PetscErrorCode
 //	monitorBubble(TS ts, PetscInt timestep, PetscReal time, Vec solution);
-
-	PetscErrorCode monitorBubbleV(
-        TS ts, PetscInt timestep, PetscReal time, Vec solution);
 
     	PetscErrorCode monitorBubbleFe(
         TS ts, PetscInt timestep, PetscReal time, Vec solution);

--- a/xolotl/solver/include/xolotl/solver/monitor/PetscMonitor0D.h
+++ b/xolotl/solver/include/xolotl/solver/monitor/PetscMonitor0D.h
@@ -57,8 +57,14 @@ public:
 	computeAlphaZr(
 		TS ts, PetscInt timestep, PetscReal time, Vec solution) override;
 
-	PetscErrorCode
-	monitorBubble(TS ts, PetscInt timestep, PetscReal time, Vec solution);
+//	PetscErrorCode
+//	monitorBubble(TS ts, PetscInt timestep, PetscReal time, Vec solution);
+
+	PetscErrorCode monitorBubbleV(
+        TS ts, PetscInt timestep, PetscReal time, Vec solution);
+
+    	PetscErrorCode monitorBubbleFe(
+        TS ts, PetscInt timestep, PetscReal time, Vec solution);
 
 protected:
 	std::shared_ptr<viz::IPlot> _scatterPlot;

--- a/xolotl/solver/src/monitor/PetscMonitor0D.cpp
+++ b/xolotl/solver/src/monitor/PetscMonitor0D.cpp
@@ -613,7 +613,8 @@ PetscMonitor0D::monitorBubble(
 	PetscCall(DMDAVecGetArrayDOFRead(da, solution, &solutionArray));
 
 	// Get the network
-	using NetworkType = core::network::VReactionNetwork;
+	using NetworkType = core::network::FeReactionNetwork;
+	// using NetworkType = core::network::VReactionNetwork;
 	using Spec = typename NetworkType::Species;
 	using Composition = typename NetworkType::Composition;
 	using Region = typename NetworkType::Region;

--- a/xolotl/solver/src/monitor/PetscMonitor0D.cpp
+++ b/xolotl/solver/src/monitor/PetscMonitor0D.cpp
@@ -142,6 +142,13 @@ PetscMonitor0D::setup(int loop)
 
 	// Set the monitor to save text file of the mean concentration of bubbles using vanadium reaction network
 	if (flagBubbleV) {
+	
+		// creating the file and writing the header
+		std::ofstream outputFile;
+    		outputFile.open("bubbleV.dat");
+    		outputFile << "#time lo_He hi_He lo_V hi_V conc" << std::endl;
+    		outputFile.close();
+    		
 		// monitorBubbleV will be called at each timestep
 		PetscCallVoid(TSMonitorSet(_ts, monitor::monitorBubbleV, this, nullptr));
 	}
@@ -642,11 +649,15 @@ PetscMonitor0D::monitorBubbleV(
 	const auto networkSize = network.getNumClusters();
 
 	// Create the output file
+	//std::ofstream outputFile;
+	//std::stringstream name;
+	//name << "bubble_v_" << timestep << ".dat";
+	//outputFile.open(name.str());
+	//outputFile << "#lo_He hi_He lo_V hi_V conc" << std::endl;
+	
+	// Appending to the output file
 	std::ofstream outputFile;
-	std::stringstream name;
-	name << "bubble_v_" << timestep << ".dat";
-	outputFile.open(name.str());
-	outputFile << "#lo_He hi_He lo_V hi_V conc" << std::endl;
+    	outputFile.open("bubbleV.dat", std::ios::app);
 
 	// Get the pointer to the beginning of the solution data for this grid point
 	gridPointSolution = solutionArray[0];
@@ -667,9 +678,10 @@ PetscMonitor0D::monitorBubbleV(
 
 		// For compatibility with previous versions, we output
 		// the value of a closed upper bound of the He and V intervals.
-		outputFile << lo[Spec::He] << " " << hi[Spec::He] - 1 << " "
-				   << lo[Spec::V] << " " << hi[Spec::V] - 1 << " "
-				   << gridPointSolution[i] << std::endl;
+		outputFile << time << " " 
+			   <<lo[Spec::He] << " " << hi[Spec::He] - 1 << " "
+		 	   << lo[Spec::V] << " " << hi[Spec::V] - 1 << " "
+			   << gridPointSolution[i] << std::endl;
 	}
 
 	// Close the file

--- a/xolotl/solver/src/monitor/PetscMonitor0D.cpp
+++ b/xolotl/solver/src/monitor/PetscMonitor0D.cpp
@@ -23,11 +23,21 @@ namespace solver
 namespace monitor
 {
 PetscErrorCode
-monitorBubble(
+monitorBubbleV(
 	TS ts, PetscInt timestep, PetscReal time, Vec solution, void* ictx)
 {
 	PetscFunctionBeginUser;
-	PetscCall(static_cast<PetscMonitor0D*>(ictx)->monitorBubble(
+	PetscCall(static_cast<PetscMonitor0D*>(ictx)->monitorBubbleV(
+		ts, timestep, time, solution));
+	PetscFunctionReturn(0);
+}
+
+PetscErrorCode
+monitorBubbleFe(
+	TS ts, PetscInt timestep, PetscReal time, Vec solution, void* ictx)
+{
+	PetscFunctionBeginUser;
+	PetscCall(static_cast<PetscMonitor0D*>(ictx)->monitorBubbleFe(
 		ts, timestep, time, solution));
 	PetscFunctionReturn(0);
 }
@@ -41,7 +51,7 @@ PetscMonitor0D::setup(int loop)
 	auto vizHandlerRegistry = _solverHandler->getVizHandler();
 
 	// Flags to launch the monitors or not
-	PetscBool flagCheck, flag1DPlot, flagBubble, flagStatus, flagAlloy,
+	PetscBool flagCheck, flag1DPlot, flagBubbleV, flagBubbleFe, flagStatus, flagAlloy,
 		flagXeRetention, flagLargest, flagZr;
 
 	// Check the option -check_collapse
@@ -54,9 +64,12 @@ PetscMonitor0D::setup(int loop)
 	// Check the option -start_stop
 	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-start_stop", &flagStatus));
 
-	// Check the option -bubble
-	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-bubble", &flagBubble));
-
+	// Check the option -bubble_v
+	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-bubble_v", &flagBubbleV));
+	
+	// Check the option -bubble_fe
+	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-bubble_fe", &flagBubbleFe));
+	
 	// Check the option -alloy
 	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-alloy", &flagAlloy));
 
@@ -127,10 +140,16 @@ PetscMonitor0D::setup(int loop)
 			TSMonitorSet(_ts, monitor::monitorScatter, this, nullptr));
 	}
 
-	// Set the monitor to save text file of the mean concentration of bubbles
-	if (flagBubble) {
-		// monitorBubble0D will be called at each timestep
-		PetscCallVoid(TSMonitorSet(_ts, monitor::monitorBubble, this, nullptr));
+	// Set the monitor to save text file of the mean concentration of bubbles using vanadium reaction network
+	if (flagBubbleV) {
+		// monitorBubbleV will be called at each timestep
+		PetscCallVoid(TSMonitorSet(_ts, monitor::monitorBubbleV, this, nullptr));
+	}
+	
+	// Set the monitor to save text file of the mean concentration of bubbles using Fe reaction network
+	if (flagBubbleFe) {
+		// monitorBubbleFe will be called at each timestep
+		PetscCallVoid(TSMonitorSet(_ts, monitor::monitorBubbleFe, this, nullptr));
 	}
 
 	// Set the monitor to output data for Alloy
@@ -591,9 +610,80 @@ PetscMonitor0D::monitorScatter(
 
 	PetscFunctionReturn(0);
 }
-
+// Bubble Monitor function for using Vanadium reaction Network
 PetscErrorCode
-PetscMonitor0D::monitorBubble(
+PetscMonitor0D::monitorBubbleV(
+	TS ts, PetscInt timestep, PetscReal time, Vec solution)
+{
+	// Initial declaration
+	double **solutionArray, *gridPointSolution;
+
+	PetscFunctionBeginUser;
+
+	// Don't do anything if it is not on the stride
+	//	if (timestep % 10 != 0)
+	//		PetscFunctionReturn(0);
+
+	// Get the da from ts
+	DM da;
+	PetscCall(TSGetDM(ts, &da));
+
+	// Get the solutionArray
+	PetscCall(DMDAVecGetArrayDOFRead(da, solution, &solutionArray));
+
+	// Get the network
+	using NetworkType = core::network::VReactionNetwork;
+	using Spec = typename NetworkType::Species;
+	using Composition = typename NetworkType::Composition;
+	using Region = typename NetworkType::Region;
+
+	// Get the network and its size
+	auto& network = dynamic_cast<NetworkType&>(_solverHandler->getNetwork());
+	const auto networkSize = network.getNumClusters();
+
+	// Create the output file
+	std::ofstream outputFile;
+	std::stringstream name;
+	name << "bubble_v_" << timestep << ".dat";
+	outputFile.open(name.str());
+	outputFile << "#lo_He hi_He lo_V hi_V conc" << std::endl;
+
+	// Get the pointer to the beginning of the solution data for this grid point
+	gridPointSolution = solutionArray[0];
+
+	// Initialize the total helium and concentration before looping
+	double concTot = 0.0, heliumTot = 0.0;
+
+	// Consider each cluster.
+	for (auto i = 0; i < networkSize; i++) {
+		auto cluster = network.getCluster(i, plsm::HostMemSpace{});
+		const Region& clReg = cluster.getRegion();
+		Composition lo = clReg.getOrigin();
+		Composition hi = clReg.getUpperLimitPoint();
+
+		if (lo.isOnAxis(Spec::I) || lo.isOnAxis(Spec::V) ||
+			lo.isOnAxis(Spec::He))
+			continue;
+
+		// For compatibility with previous versions, we output
+		// the value of a closed upper bound of the He and V intervals.
+		outputFile << lo[Spec::He] << " " << hi[Spec::He] - 1 << " "
+				   << lo[Spec::V] << " " << hi[Spec::V] - 1 << " "
+				   << gridPointSolution[i] << std::endl;
+	}
+
+	// Close the file
+	outputFile.close();
+
+	// Restore the solutionArray
+	PetscCall(DMDAVecRestoreArrayDOFRead(da, solution, &solutionArray));
+
+	PetscFunctionReturn(0);
+}
+
+// Bubble Monitor function for using Fe reaction Network
+PetscErrorCode
+PetscMonitor0D::monitorBubbleFe(
 	TS ts, PetscInt timestep, PetscReal time, Vec solution)
 {
 	// Initial declaration
@@ -614,7 +704,6 @@ PetscMonitor0D::monitorBubble(
 
 	// Get the network
 	using NetworkType = core::network::FeReactionNetwork;
-	// using NetworkType = core::network::VReactionNetwork;
 	using Spec = typename NetworkType::Species;
 	using Composition = typename NetworkType::Composition;
 	using Region = typename NetworkType::Region;
@@ -626,7 +715,7 @@ PetscMonitor0D::monitorBubble(
 	// Create the output file
 	std::ofstream outputFile;
 	std::stringstream name;
-	name << "bubble_" << timestep << ".dat";
+	name << "bubble_fe_" << timestep << ".dat";
 	outputFile.open(name.str());
 	outputFile << "#lo_He hi_He lo_V hi_V conc" << std::endl;
 

--- a/xolotl/solver/src/monitor/PetscMonitor0D.cpp
+++ b/xolotl/solver/src/monitor/PetscMonitor0D.cpp
@@ -140,13 +140,13 @@ PetscMonitor0D::setup(int loop)
 			TSMonitorSet(_ts, monitor::monitorScatter, this, nullptr));
 	}
 
-	// Set the monitor to save text file of the mean concentration of bubbles using vanadium reaction network
+	// Set the monitor to save text file of the integrated quatities using vanadium reaction network
 	if (flagBubbleV) {
 	
 		// creating the file and writing the header
 		std::ofstream outputFile;
     		outputFile.open("bubbleV.dat");
-    		outputFile << "#time lo_He hi_He lo_V hi_V conc" << std::endl;
+    		outputFile << "#time totalHe totalV bubbleDensity" << std::endl;
     		outputFile.close();
     		
 		// monitorBubbleV will be called at each timestep
@@ -647,13 +647,6 @@ PetscMonitor0D::monitorBubbleV(
 	// Get the network and its size
 	auto& network = dynamic_cast<NetworkType&>(_solverHandler->getNetwork());
 	const auto networkSize = network.getNumClusters();
-
-	// Create the output file
-	//std::ofstream outputFile;
-	//std::stringstream name;
-	//name << "bubble_v_" << timestep << ".dat";
-	//outputFile.open(name.str());
-	//outputFile << "#lo_He hi_He lo_V hi_V conc" << std::endl;
 	
 	// Appending to the output file
 	std::ofstream outputFile;
@@ -663,7 +656,12 @@ PetscMonitor0D::monitorBubbleV(
 	gridPointSolution = solutionArray[0];
 
 	// Initialize the total helium and concentration before looping
-	double concTot = 0.0, heliumTot = 0.0;
+	// double concTot = 0.0, heliumTot = 0.0;
+	
+	// Initialize the integrated quantities, totalHe, totalV and bubbledensity before looping
+	double totalHe = 0.0;
+	double totalV = 0.0;
+	double bubbleDensity = 0.0;
 
 	// Consider each cluster.
 	for (auto i = 0; i < networkSize; i++) {
@@ -675,16 +673,26 @@ PetscMonitor0D::monitorBubbleV(
 		if (lo.isOnAxis(Spec::I) || lo.isOnAxis(Spec::V) ||
 			lo.isOnAxis(Spec::He))
 			continue;
+		double conc = gridPointSolution[i];
 
-		// For compatibility with previous versions, we output
-		// the value of a closed upper bound of the He and V intervals.
-		outputFile << time << " " 
-			   <<lo[Spec::He] << " " << hi[Spec::He] - 1 << " "
-		 	   << lo[Spec::V] << " " << hi[Spec::V] - 1 << " "
-			   << gridPointSolution[i] << std::endl;
+		// Average number of He and V
+		double avgHe = 0.5 * (lo[Spec::He] + (hi[Spec::He] - 1));
+		double avgV =  0.5 * (lo[Spec::V] + (hi[Spec::V] - 1));
+
+		// Total number of He and Vacancies
+		totalHe += avgHe * conc;
+		totalV += avgV * conc;
+
+		// bubble density
+		bubbleDensity += conc;	
 	}
 
-	// Close the file
+	// write and close the file
+	outputFile << time << " " 
+	  	   << totalHe << " "
+		   << totalV << " "
+	    	   << bubbleDensity << " "
+	    	   << std::endl;
 	outputFile.close();
 
 	// Restore the solutionArray

--- a/xolotl/solver/src/monitor/PetscMonitor0D.cpp
+++ b/xolotl/solver/src/monitor/PetscMonitor0D.cpp
@@ -23,21 +23,21 @@ namespace solver
 namespace monitor
 {
 PetscErrorCode
-monitorBubbleV(
-	TS ts, PetscInt timestep, PetscReal time, Vec solution, void* ictx)
-{
-	PetscFunctionBeginUser;
-	PetscCall(static_cast<PetscMonitor0D*>(ictx)->monitorBubbleV(
-		ts, timestep, time, solution));
-	PetscFunctionReturn(0);
-}
-
-PetscErrorCode
 monitorBubbleFe(
 	TS ts, PetscInt timestep, PetscReal time, Vec solution, void* ictx)
 {
 	PetscFunctionBeginUser;
 	PetscCall(static_cast<PetscMonitor0D*>(ictx)->monitorBubbleFe(
+		ts, timestep, time, solution));
+	PetscFunctionReturn(0);
+}
+
+PetscErrorCode
+computeV(
+	TS ts, PetscInt timestep, PetscReal time, Vec solution, void* ictx)
+{
+	PetscFunctionBeginUser;
+	PetscCall(static_cast<PetscMonitor0D*>(ictx)->computeV(
 		ts, timestep, time, solution));
 	PetscFunctionReturn(0);
 }
@@ -51,8 +51,8 @@ PetscMonitor0D::setup(int loop)
 	auto vizHandlerRegistry = _solverHandler->getVizHandler();
 
 	// Flags to launch the monitors or not
-	PetscBool flagCheck, flag1DPlot, flagBubbleV, flagBubbleFe, flagStatus, flagAlloy,
-		flagXeRetention, flagLargest, flagZr;
+	PetscBool flagCheck, flag1DPlot, flagBubbleFe, flagStatus, flagAlloy,
+		flagXeRetention, flagLargest, flagZr, flagV;
 
 	// Check the option -check_collapse
 	PetscCallVoid(
@@ -64,9 +64,6 @@ PetscMonitor0D::setup(int loop)
 	// Check the option -start_stop
 	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-start_stop", &flagStatus));
 
-	// Check the option -bubble_v
-	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-bubble_v", &flagBubbleV));
-	
 	// Check the option -bubble_fe
 	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-bubble_fe", &flagBubbleFe));
 	
@@ -75,6 +72,9 @@ PetscMonitor0D::setup(int loop)
 
 	// Check the option -alpha_zr
 	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-alpha_zr", &flagZr));
+	
+	// Check the option -v
+	PetscCallVoid(PetscOptionsHasName(NULL, NULL, "-v", &flagV));
 	// Check the option -xenon_retention
 	PetscCallVoid(
 		PetscOptionsHasName(NULL, NULL, "-xenon_retention", &flagXeRetention));
@@ -139,19 +139,6 @@ PetscMonitor0D::setup(int loop)
 		PetscCallVoid(
 			TSMonitorSet(_ts, monitor::monitorScatter, this, nullptr));
 	}
-
-	// Set the monitor to save text file of the integrated quatities using vanadium reaction network
-	if (flagBubbleV) {
-	
-		// creating the file and writing the header
-		std::ofstream outputFile;
-    		outputFile.open("bubbleV.dat");
-    		outputFile << "#time totalHe totalV bubbleDensity" << std::endl;
-    		outputFile.close();
-    		
-		// monitorBubbleV will be called at each timestep
-		PetscCallVoid(TSMonitorSet(_ts, monitor::monitorBubbleV, this, nullptr));
-	}
 	
 	// Set the monitor to save text file of the mean concentration of bubbles using Fe reaction network
 	if (flagBubbleFe) {
@@ -173,6 +160,15 @@ PetscMonitor0D::setup(int loop)
 		// computeAlphaZr will be called at each timestep
 		PetscCallVoid(
 			TSMonitorSet(_ts, monitor::computeAlphaZr, this, nullptr));
+	}
+
+	// Set the monitor to output data for V
+	if (flagV) {
+		_solverHandler->getNetwork().writeMonitorOutputHeader();
+
+		// computeV will be called at each timestep
+		PetscCallVoid(
+			TSMonitorSet(_ts, monitor::computeV, this, nullptr));
 	}
 
 	// Set the monitor to compute the xenon content
@@ -539,6 +535,34 @@ PetscMonitor0D::computeAlphaZr(
 }
 
 PetscErrorCode
+PetscMonitor0D::computeV(
+	TS ts, PetscInt timestep, PetscReal time, Vec solution)
+{
+	PetscFunctionBeginUser;
+
+	// Get the da from ts
+	DM da;
+	PetscCall(TSGetDM(ts, &da));
+
+	// Get the array of concentration
+	PetscOffsetView<const PetscScalar**> concs;
+	PetscCall(DMDAVecGetKokkosOffsetViewDOF(da, solution, &concs));
+	auto concOffset = subview(concs, 0, Kokkos::ALL).view();
+
+	using NetworkType = core::network::VReactionNetwork;
+	auto& network = dynamic_cast<NetworkType&>(_solverHandler->getNetwork());
+
+	auto myData = network.getMonitorDataValues(concOffset, 1.0);
+
+	network.writeMonitorDataLine(myData, time);
+
+	// Restore the PETSc solution array
+	PetscCall(DMDAVecRestoreKokkosOffsetViewDOF(da, solution, &concs));
+
+	PetscFunctionReturn(0);
+}
+
+PetscErrorCode
 PetscMonitor0D::monitorScatter(
 	TS ts, PetscInt timestep, PetscReal time, Vec solution)
 {
@@ -617,89 +641,7 @@ PetscMonitor0D::monitorScatter(
 
 	PetscFunctionReturn(0);
 }
-// Bubble Monitor function for using Vanadium reaction Network
-PetscErrorCode
-PetscMonitor0D::monitorBubbleV(
-	TS ts, PetscInt timestep, PetscReal time, Vec solution)
-{
-	// Initial declaration
-	double **solutionArray, *gridPointSolution;
 
-	PetscFunctionBeginUser;
-
-	// Don't do anything if it is not on the stride
-	//	if (timestep % 10 != 0)
-	//		PetscFunctionReturn(0);
-
-	// Get the da from ts
-	DM da;
-	PetscCall(TSGetDM(ts, &da));
-
-	// Get the solutionArray
-	PetscCall(DMDAVecGetArrayDOFRead(da, solution, &solutionArray));
-
-	// Get the network
-	using NetworkType = core::network::VReactionNetwork;
-	using Spec = typename NetworkType::Species;
-	using Composition = typename NetworkType::Composition;
-	using Region = typename NetworkType::Region;
-
-	// Get the network and its size
-	auto& network = dynamic_cast<NetworkType&>(_solverHandler->getNetwork());
-	const auto networkSize = network.getNumClusters();
-	
-	// Appending to the output file
-	std::ofstream outputFile;
-    	outputFile.open("bubbleV.dat", std::ios::app);
-
-	// Get the pointer to the beginning of the solution data for this grid point
-	gridPointSolution = solutionArray[0];
-
-	// Initialize the total helium and concentration before looping
-	// double concTot = 0.0, heliumTot = 0.0;
-	
-	// Initialize the integrated quantities, totalHe, totalV and bubbledensity before looping
-	double totalHe = 0.0;
-	double totalV = 0.0;
-	double bubbleDensity = 0.0;
-
-	// Consider each cluster.
-	for (auto i = 0; i < networkSize; i++) {
-		auto cluster = network.getCluster(i, plsm::HostMemSpace{});
-		const Region& clReg = cluster.getRegion();
-		Composition lo = clReg.getOrigin();
-		Composition hi = clReg.getUpperLimitPoint();
-
-		if (lo.isOnAxis(Spec::I) || lo.isOnAxis(Spec::V) ||
-			lo.isOnAxis(Spec::He))
-			continue;
-		double conc = gridPointSolution[i];
-
-		// Average number of He and V
-		double avgHe = 0.5 * (lo[Spec::He] + (hi[Spec::He] - 1));
-		double avgV =  0.5 * (lo[Spec::V] + (hi[Spec::V] - 1));
-
-		// Total number of He and Vacancies
-		totalHe += avgHe * conc;
-		totalV += avgV * conc;
-
-		// bubble density
-		bubbleDensity += conc;	
-	}
-
-	// write and close the file
-	outputFile << time << " " 
-	  	   << totalHe << " "
-		   << totalV << " "
-	    	   << bubbleDensity << " "
-	    	   << std::endl;
-	outputFile.close();
-
-	// Restore the solutionArray
-	PetscCall(DMDAVecRestoreArrayDOFRead(da, solution, &solutionArray));
-
-	PetscFunctionReturn(0);
-}
 
 // Bubble Monitor function for using Fe reaction Network
 PetscErrorCode


### PR DESCRIPTION
## Summary
This change updates the `monitorBubble` function to use `FeReactionNetwork` instead of `VReactionNetwork`.

## Changes Made
- Replaced `VReactionNetwork` with `FeReactionNetwork` in `monitorBubble`
- No other changes were introduced

## Related Files
- `PetscMonitor0D.cpp`